### PR TITLE
Vicky/authorize request

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ processing library for PHP. This package implements PayPal v2 API support for Om
 The following gateways and functions are provided by this package:
 
 * PayPal_Checkout (PayPal Checkout)
-    * `completePurchase()`
     * `authorize()`
+    * `completePurchase()`
 
 For general usage instructions, please see the main [Omnipay](https://github.com/thephpleague/omnipay) repository.

--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ The following gateways and functions are provided by this package:
 
 * PayPal_Checkout (PayPal Checkout)
     * `completePurchase()`
+    * `authorize()`
 
 For general usage instructions, please see the main [Omnipay](https://github.com/thephpleague/omnipay) repository.

--- a/src/CheckoutGateway.php
+++ b/src/CheckoutGateway.php
@@ -229,7 +229,7 @@ class CheckoutGateway extends AbstractGateway
     }
 
     /**
-     * @param array $parameters ['order_id', 'payer_id]
+     * @param array $parameters ['order_id']
      * @return AbstractRequest
      */
     public function authorize(array $parameters = [])

--- a/src/CheckoutGateway.php
+++ b/src/CheckoutGateway.php
@@ -3,6 +3,7 @@
 namespace Omnipay\PayPal;
 
 use Omnipay\Common\AbstractGateway;
+use Omnipay\PayPal\Message\AuthorizeRequest;
 use Omnipay\PayPal\Message\CaptureRequest;
 use Omnipay\Common\Message\AbstractRequest;
 use Omnipay\PayPal\Message\RestTokenRequest;
@@ -16,7 +17,6 @@ use Omnipay\PayPal\Message\RestTokenRequest;
  * @method \Omnipay\Common\Message\RequestInterface updateCard(array $options = [])
  * @method \Omnipay\Common\Message\RequestInterface deleteCard(array $options = [])
  * @method \Omnipay\Common\Message\RequestInterface void(array $options = [])
- * @method \Omnipay\Common\Message\RequestInterface authorize(array $options = [])
  * @method \Omnipay\Common\Message\RequestInterface completeAuthorize(array $options = [])
  * @method \Omnipay\Common\Message\RequestInterface purchase(array $options = [])
  *
@@ -226,5 +226,14 @@ class CheckoutGateway extends AbstractGateway
     public function completePurchase(array $parameters = [])
     {
         return $this->createRequest(CaptureRequest::class, $parameters);
+    }
+
+    /**
+     * @param array $parameters ['order_id', 'payer_id]
+     * @return AbstractRequest
+     */
+    public function authorize(array $parameters = [])
+    {
+        return $this->createRequest(AuthorizeRequest::class, $parameters);
     }
 }

--- a/src/CheckoutGateway.php
+++ b/src/CheckoutGateway.php
@@ -3,9 +3,9 @@
 namespace Omnipay\PayPal;
 
 use Omnipay\Common\AbstractGateway;
-use Omnipay\PayPal\Message\AuthorizeRequest;
 use Omnipay\PayPal\Message\CaptureRequest;
 use Omnipay\Common\Message\AbstractRequest;
+use Omnipay\PayPal\Message\AuthorizeRequest;
 use Omnipay\PayPal\Message\RestTokenRequest;
 
 /**

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -34,6 +34,13 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      */
     protected $liveEndpoint = 'https://api.paypal.com';
 
+    /**
+     * PayPal Payer ID
+     *
+     * @var string PayerID
+     */
+    protected $payerId = null;
+
     protected $referrerCode;
 
     /**
@@ -84,6 +91,23 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function setSecret($value): AbstractRequest
     {
         return $this->setParameter('secret', $value);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPayerId()
+    {
+        return $this->getParameter('payerId');
+    }
+
+    /**
+     * @param $value
+     * @return AbstractRequest
+     */
+    public function setPayerId($value): AbstractRequest
+    {
+        return $this->setParameter('payerId', $value);
     }
 
     /**

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -34,13 +34,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      */
     protected $liveEndpoint = 'https://api.paypal.com';
 
-    /**
-     * PayPal Payer ID
-     *
-     * @var string PayerID
-     */
-    protected $payerId = null;
-
     protected $referrerCode;
 
     /**
@@ -91,23 +84,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function setSecret($value): AbstractRequest
     {
         return $this->setParameter('secret', $value);
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getPayerId()
-    {
-        return $this->getParameter('payerId');
-    }
-
-    /**
-     * @param $value
-     * @return AbstractRequest
-     */
-    public function setPayerId($value): AbstractRequest
-    {
-        return $this->setParameter('payerId', $value);
     }
 
     /**

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -51,11 +51,9 @@ class AuthorizeRequest extends AbstractRequest
     public function getData()
     {
         $this->validate('orderId');
-        $this->validate('payerId');
 
         return [
             'order_id' => $this->getOrderId(),
-            'payer_id' => $this->getPayerId()
         ];
     }
 

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Omnipay\PayPal\Message;
+
+use Omnipay\Common\Exception\InvalidRequestException;
+
+/**
+ * <code>
+ *   // Before the transaction has been processed, we need to authorize it.
+ *   $transaction = $gateway->authorize([
+ *       'order_id' => '123',
+ *   ]);
+ * </code>
+ *
+ * @link https://developer.paypal.com/docs/api/orders/v2/#orders_authorize
+ */
+class AuthorizeRequest extends AbstractRequest
+{
+    /**
+     * @return mixed
+     */
+    public function getOrderId()
+    {
+        return $this->getParameter('orderId');
+    }
+
+    /**
+     * @param $value
+     * @return AbstractRequest
+     */
+    public function setOrderId($value): AbstractRequest
+    {
+        return $this->setParameter('orderId', $value);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPayerId()
+    {
+        return $this->getParameter('payerId');
+    }
+
+    /**
+     * Get the raw data array for this message. The format of this varies from gateway to
+     * gateway, but will usually be either an associative array, or a SimpleXMLElement.
+     *
+     * @return mixed
+     * @throws InvalidRequestException
+     */
+    public function getData()
+    {
+        $this->validate('orderId');
+        $this->validate('payerId');
+
+        return [
+            'order_id' => $this->getOrderId(),
+            'payer_id' => $this->getPayerId()
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return parent::getEndpoint() . '/checkout/orders/' . $this->getOrderId() . '/authorize';
+    }
+
+    /**
+     * @param $data
+     * @param $statusCode
+     * @return OrdersResponse
+     */
+    protected function createResponse($data, $statusCode)
+    {
+        return $this->response = new OrdersResponse($this, $data, $statusCode);
+    }
+}

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -34,14 +34,6 @@ class AuthorizeRequest extends AbstractRequest
     }
 
     /**
-     * @return mixed
-     */
-    public function getPayerId()
-    {
-        return $this->getParameter('payerId');
-    }
-
-    /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.
      *

--- a/tests/CheckoutGatewayTest.php
+++ b/tests/CheckoutGatewayTest.php
@@ -27,6 +27,7 @@ class CheckoutGatewayTest extends GatewayTestCase
 
         $this->params = [
             'order_id' => 'test',
+            'payer_id' => 'QYR5Z8XDVJNXQ'
         ];
     }
 
@@ -81,5 +82,27 @@ class CheckoutGatewayTest extends GatewayTestCase
         $this->assertTrue($response->isSuccessful());
         $this->assertEquals('d9f80740-38f0-11e8-b467-0ed5f89f718b', $response->getTransactionReference());
         $this->assertNull($response->getMessage());
+    }
+
+    public function testAuthorizeSuccess()
+    {
+        $this->setMockHttpResponse('RestAuthorizeSuccess.txt');
+
+        $response = $this->gateway->authorize($this->params)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertEquals('d9f80740-38f0-11e8-b467-0ed5f89f718b', $response->getTransactionReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testAuthorizeFailure()
+    {
+        $this->setMockHttpResponse('RestAuthorizeFailure.txt');
+
+        $response = $this->gateway->authorize($this->params)->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('Authorization failed due to insufficient permissions, or failed business validation.', $response->getMessage());
     }
 }

--- a/tests/CheckoutGatewayTest.php
+++ b/tests/CheckoutGatewayTest.php
@@ -103,6 +103,6 @@ class CheckoutGatewayTest extends GatewayTestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertNull($response->getTransactionReference());
-        $this->assertSame('Authorization failed due to insufficient permissions, or failed business validation.', $response->getMessage());
+        $this->assertSame('This request is invalid due to the current state of the payment.', $response->getMessage());
     }
 }

--- a/tests/Mock/RestAuthorizeFailure.txt
+++ b/tests/Mock/RestAuthorizeFailure.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 400 Bad Request
+Server: Apache-Coyote/1.1
+PROXY_SERVER_INFO: host=slcsbplatformapiserv3002.slc.paypal.com;threadId=533
+Paypal-Debug-Id: 65f24674659dc
+SERVER_INFO: paymentsplatformserv:v1.payments.payment&CalThreadId=166&TopLevelTxnStartTime=14b8c851ff1&Host=slcsbpaymentsplatformserv3001.slc.paypal.com&pid=12653
+Content-Language: *
+Date: Sun, 15 Feb 2015 09:15:09 GMT
+Connection: close, close
+Content-Type: application/json
+Content-Length: 235
+
+{"name":"NOT_AUTHORIZED","message":"Authorization failed due to insufficient permissions, or failed business validation.","information_link":"https://developer.paypal.com/docs/api/orders/v2/#error-NOT_AUTHORIZED","debug_id":"65f24674659dc"}

--- a/tests/Mock/RestAuthorizeFailure.txt
+++ b/tests/Mock/RestAuthorizeFailure.txt
@@ -9,4 +9,4 @@ Connection: close, close
 Content-Type: application/json
 Content-Length: 235
 
-{"name":"NOT_AUTHORIZED","message":"Authorization failed due to insufficient permissions, or failed business validation.","information_link":"https://developer.paypal.com/docs/api/orders/v2/#error-NOT_AUTHORIZED","debug_id":"65f24674659dc"}
+{"name":"PAYMENT_STATE_INVALID","message":"This request is invalid due to the current state of the payment.","information_link":"https://developer.paypal.com/docs/api/orders/v2/#error-NOT_AUTHORIZED","debug_id":"65f24674659dc"}

--- a/tests/Mock/RestAuthorizeSuccess.txt
+++ b/tests/Mock/RestAuthorizeSuccess.txt
@@ -1,0 +1,88 @@
+HTTP/1.1 201 Created
+Server: Apache-Coyote/1.1
+PROXY_SERVER_INFO: host=slcsbplatformapiserv3001.slc.paypal.com;threadId=216
+Paypal-Debug-Id: 539b1c0678b08
+SERVER_INFO: paymentsplatformserv:v1.payments.payment&CalThreadId=4342&TopLevelTxnStartTime=14b8c84b1f3&Host=slcsbpaymentsplatformserv3002.slc.paypal.com&pid=8929
+Content-Language: *
+Date: Sun, 15 Feb 2015 09:14:43 GMT
+Content-Type: application/json
+Content-Length: 1632
+
+{
+  "id": "5O190127TN364715T",
+  "status": "COMPLETED",
+  "payer": {
+    "name": {
+      "given_name": "John",
+      "surname": "Doe"
+    },
+    "email_address": "customer@example.com",
+    "payer_id": "QYR5Z8XDVJNXQ"
+  },
+  "purchase_units": [
+    {
+      "reference_id": "d9f80740-38f0-11e8-b467-0ed5f89f718b",
+      "shipping": {
+        "address": {
+          "address_line_1": "2211 N First Street",
+          "address_line_2": "Building 17",
+          "admin_area_2": "San Jose",
+          "admin_area_1": "CA",
+          "postal_code": "95131",
+          "country_code": "US"
+        }
+      },
+      "payments": {
+        "authorizations": [
+          {
+            "id": "0AW2184448108334S",
+            "status": "CREATED",
+            "amount": {
+              "currency_code": "USD",
+              "value": "100.00"
+            },
+            "seller_protection": {
+              "status": "ELIGIBLE",
+              "dispute_categories": [
+                "ITEM_NOT_RECEIVED",
+                "UNAUTHORIZED_TRANSACTION"
+              ]
+            },
+            "expiration_time": "2018-05-01T21:20:49Z",
+            "create_time": "2018-04-01T21:20:49Z",
+            "update_time": "2018-04-01T21:20:49Z",
+            "links": [
+              {
+                "href": "https://api.paypal.com/v2/payments/authorizations/0AW2184448108334S",
+                "rel": "self",
+                "method": "GET"
+              },
+              {
+                "href": "https://api.paypal.com/v2/payments/authorizations/0AW2184448108334S/capture",
+                "rel": "capture",
+                "method": "POST"
+              },
+              {
+                "href": "https://api.paypal.com/v2/payments/authorizations/0AW2184448108334S/void",
+                "rel": "void",
+                "method": "POST"
+              },
+              {
+                "href": "https://api.paypal.com/v2/payments/authorizations/0AW2184448108334S/reauthorize",
+                "rel": "reauthorize",
+                "method": "POST"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "links": [
+    {
+      "href": "https://api.paypal.com/v2/checkout/orders/5O190127TN364715T",
+      "rel": "self",
+      "method": "GET"
+    }
+  ]
+}

--- a/tests/Orders/AuthorizeRequestTest.php
+++ b/tests/Orders/AuthorizeRequestTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Omnipay\PayPal\Orders;
+
+use Omnipay\Tests\TestCase;
+use Omnipay\PayPal\Message\AuthorizeRequest;
+
+class AuthorizeRequestTest extends TestCase
+{
+    /**
+     * @var AuthorizeRequest
+     */
+    private $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $client = $this->getHttpClient();
+        $request = $this->getHttpRequest();
+
+        $this->request = new AuthorizeRequest($client, $request);
+
+        $this->request->initialize([
+            'orderId' => 'test',
+            'payerId' => 'QYR5Z8XDVJNXQ',
+        ]);
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+        $this->assertEquals('test', $data['order_id'], $data['payer_id']);
+    }
+
+    public function testEndpoint()
+    {
+        $this->request->setOrderId('ABC-123');
+        $this->assertStringEndsWith('/checkout/orders/ABC-123/authorize', $this->request->getEndpoint());
+    }
+}

--- a/tests/Orders/ResponseTest.php
+++ b/tests/Orders/ResponseTest.php
@@ -52,7 +52,7 @@ class ResponseTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertNull($response->getTransactionReference());
-        $this->assertEquals('Authorization failed due to insufficient permissions, or failed business validation.', $response->getMessage());
+        $this->assertEquals('This request is invalid due to the current state of the payment.', $response->getMessage());
     }
 
     public function testTokenFailure()

--- a/tests/Orders/ResponseTest.php
+++ b/tests/Orders/ResponseTest.php
@@ -31,6 +31,30 @@ class ResponseTest extends TestCase
         $this->assertEquals('This request is invalid due to the current state of the payment', $response->getMessage());
     }
 
+    public function testAuthorizeSuccess()
+    {
+        $httpResponse = $this->getMockHttpResponse('RestAuthorizeSuccess.txt');
+        $data = json_decode($httpResponse->getBody()->getContents(), true);
+
+        $response = new OrdersResponse($this->getMockRequest(), $data, $httpResponse->getStatusCode());
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertEquals('d9f80740-38f0-11e8-b467-0ed5f89f718b', $response->getTransactionReference());
+        $this->assertEquals('COMPLETED', $response->getStatus());
+    }
+
+    public function testAuthorizeFailure()
+    {
+        $httpResponse = $this->getMockHttpResponse('RestAuthorizeFailure.txt');
+        $data = json_decode($httpResponse->getBody()->getContents(), true);
+
+        $response = new OrdersResponse($this->getMockRequest(), $data, $httpResponse->getStatusCode());
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertEquals('Authorization failed due to insufficient permissions, or failed business validation.', $response->getMessage());
+    }
+
     public function testTokenFailure()
     {
         $httpResponse = $this->getMockHttpResponse('RestTokenFailure.txt');


### PR DESCRIPTION
This **PR** includes the following changes:

### Create a new authorize request
This file includes the following functions:
- Getter and Setter for `OrderID`
- Getter for `data`
- Getter for `endpoint` is `/v2/checkout/orders/{id}/authorize` (see [PayPal](https://developer.paypal.com/docs/api/orders/v2/#orders_authorize) docs)
- A method that returns a new **orders response** which takes the `data` and the `status code` as arguments

### Add a method named authorize in the Checkout Gateway
- The method takes an array of `parameters` as an argument
- The method will return a new request using the **Authorize request** created. 

### Create examples of Authorization Failure and Success
- **success:** create a mockup of a response from the example in [PayPal](https://developer.paypal.com/docs/api/orders/v2/#orders_authorize) docs
- **failure**: create a mockup of a response from the example in the **complete purchase** Mockup response

### Added tests to check the implementation
- **AuthorizeRequestTest**: test `data` received and `endpoint`
- **ResponseTest**: test Authorization `failure` and `success` response examples
- **CheckoutGateway**: add tests for Authorization `failure` and `success`

#### _Please Note_:
The difference between **ResponseTest** and **CheckoutGateway** is that:
  -  **ResponseTest** uses the method that **gets** the `MockHttpResponse` for a client by the file name 
  - **CheckoutGateway** uses the method that **sets** the `MockHttpResponse` from the mockup on the next client request.


