### PR TITLE
Added missing methods to the CheckoutGateway doc block

### DIFF
--- a/src/CheckoutGateway.php
+++ b/src/CheckoutGateway.php
@@ -11,14 +11,17 @@ use Omnipay\PayPal\Message\RestTokenRequest;
 /**
  * PayPal Checkout Class
  *
- * @method \Omnipay\Common\Message\RequestInterface capture(array $options = [])
+ * @method \Omnipay\Common\Message\RequestInterface void(array $options = [])
  * @method \Omnipay\Common\Message\RequestInterface refund(array $options = [])
+ * @method \Omnipay\Common\Message\RequestInterface capture(array $options = [])
+ * @method \Omnipay\Common\Message\RequestInterface purchase(array $options = [])
  * @method \Omnipay\Common\Message\RequestInterface createCard(array $options = [])
  * @method \Omnipay\Common\Message\RequestInterface updateCard(array $options = [])
  * @method \Omnipay\Common\Message\RequestInterface deleteCard(array $options = [])
- * @method \Omnipay\Common\Message\RequestInterface void(array $options = [])
+ * @method \Omnipay\Common\Message\RequestInterface authorize(array $options = array())
+ * @method \Omnipay\Common\Message\RequestInterface fetchTransaction(array $options = [])
  * @method \Omnipay\Common\Message\RequestInterface completeAuthorize(array $options = [])
- * @method \Omnipay\Common\Message\RequestInterface purchase(array $options = [])
+ * @method \Omnipay\Common\Message\RequestInterface acceptNotification(array $options = array())
  *
  * ### Example
  * // Create a gateway for the PayPal CheckoutGateway


### PR DESCRIPTION
This **PR** contains an update of the `CheckoutGateway` class, which include the missing methods from the **Gateway Interface** in the doc block at the top of the class. 

Methods added include:
- `acceptNotification(array $options = array())`
- `authorize(array $options = array())`
- ` fetchTransaction(array $options = [])`

The methods were also organised by length. 